### PR TITLE
ACS-6359: Disable PMD.GenericsNaming rule

### DIFF
--- a/pmd-ruleset.xml
+++ b/pmd-ruleset.xml
@@ -88,7 +88,6 @@
             <property name="explicitLambdaParameterPattern" value="([a-z][a-zA-Z0-9]*|__*)" />
         </properties>
     </rule>
-    <rule ref="category/java/codestyle.xml/GenericsNaming" />
     <rule ref="category/java/codestyle.xml/IdenticalCatchBranches" />
     <rule ref="category/java/codestyle.xml/LinguisticNaming" />
     <rule ref="category/java/codestyle.xml/LocalHomeNamingConvention" />


### PR DESCRIPTION
https://alfresco.atlassian.net/browse/ACS-6359