### PR TITLE
Update to include rules from PMD 7.1.0 and 7.3.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Alfresco PMD Ruleset
+
+The default PMD ruleset for Java projects in Alfresco.
+
+The rules in this project are provided by a particular version of PMD and using an earlier version of PMD with the ruleset will cause PMD to exit with an error.
+
+The `ya-pmd-scan` tool uses rulesets from this project by default. This will be master unless there is a tag starting with the PMD version (it's also possible to override this behaviour with the property `pmd-ruleset-ref-override`). This allows the addition of new rules from later versions of PMD providing a tag is created for any older versions.
+
+## Example - Adding new rules included in PMD 7.3.0
+
+Scenario PMD 7.3.0 includes some new rules and the existing ruleset was compatible with PMD 7.0.0+.
+
+1. Gather a list of the old PMD releases from 7.0.0 onwards (`7.0.0`, `7.1.0` and `7.2.0`).
+2. Create a tag at the existing HEAD for each of these using the current date (e.g. `7.0.0_20240723`, `7.1.0_20240723` and `7.2.0_20240723`).
+3. Push the tags.
+4. Add the new rules and create a pull request.
+5. Merge the reviewed pull request into master.
+
+The creation and pushing of the tags can be done with the script:
+
+```bash
+update_pmd.sh 7.0.0 7.1.0 7.2.0
+```

--- a/pmd-ruleset.xml
+++ b/pmd-ruleset.xml
@@ -224,7 +224,6 @@
     <rule ref="category/java/errorprone.xml/CloseResource" />
     <rule ref="category/java/errorprone.xml/CompareObjectsWithEquals" />
     <rule ref="category/java/errorprone.xml/ComparisonWithNaN" />
-    <rule ref="category/java/errorprone.xml/ConfusingArgumentToVarargsMethod" />
     <rule ref="category/java/errorprone.xml/DetachedTestCase" />
     <rule ref="category/java/errorprone.xml/DoNotCallGarbageCollectionExplicitly" />
     <rule ref="category/java/errorprone.xml/DoNotExtendJavaLangThrowable" />

--- a/pmd-ruleset.xml
+++ b/pmd-ruleset.xml
@@ -42,7 +42,7 @@
     <rule ref="category/java/bestpractices.xml/JUnitAssertionsShouldIncludeMessage" />
     <rule ref="category/java/bestpractices.xml/JUnitTestsShouldIncludeAssert">
         <properties>
-            <property name="extraAssertMethodNames" value="then,verify" />
+            <property name="extraAssertMethodNames" value="should,then,verify" />
         </properties>
     </rule>
     <rule ref="category/java/bestpractices.xml/JUnitUseExpected" />

--- a/pmd-ruleset.xml
+++ b/pmd-ruleset.xml
@@ -40,7 +40,11 @@
     <!-- The rule will also complain if we use TestNG @Test annotations (see https://github.com/pmd/pmd/issues/4634 ) -->
     <rule ref="category/java/bestpractices.xml/JUnit4TestShouldUseTestAnnotation" />
     <rule ref="category/java/bestpractices.xml/JUnitAssertionsShouldIncludeMessage" />
-    <rule ref="category/java/bestpractices.xml/JUnitTestsShouldIncludeAssert" />
+    <rule ref="category/java/bestpractices.xml/JUnitTestsShouldIncludeAssert">
+        <properties>
+            <property name="extraAssertMethodNames" value="then,verify" />
+        </properties>
+    </rule>
     <rule ref="category/java/bestpractices.xml/JUnitUseExpected" />
     <rule ref="category/java/bestpractices.xml/LooseCoupling" />
     <rule ref="category/java/bestpractices.xml/MethodReturnsInternalArray" />
@@ -53,12 +57,14 @@
     <rule ref="category/java/bestpractices.xml/ReplaceVectorWithList" />
     <rule ref="category/java/bestpractices.xml/SimplifiableTestAssertion" />
     <rule ref="category/java/bestpractices.xml/SystemPrintln" />
+    <rule ref="category/java/bestpractices.xml/UnnecessaryVarargsArrayCreation" />
     <rule ref="category/java/bestpractices.xml/UnusedAssignment" />
     <rule ref="category/java/bestpractices.xml/UnusedFormalParameter" />
     <rule ref="category/java/bestpractices.xml/UnusedLocalVariable" />
     <rule ref="category/java/bestpractices.xml/UnusedPrivateField" />
     <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod" />
     <rule ref="category/java/bestpractices.xml/UseCollectionIsEmpty" />
+    <rule ref="category/java/bestpractices.xml/UseEnumCollections" />
     <rule ref="category/java/bestpractices.xml/UseStandardCharsets" />
     <rule ref="category/java/bestpractices.xml/UseTryWithResources" />
     <rule ref="category/java/bestpractices.xml/UseVarargs" />
@@ -89,6 +95,12 @@
         </properties>
     </rule>
     <rule ref="category/java/codestyle.xml/IdenticalCatchBranches" />
+    <rule ref="category/java/codestyle.xml/LambdaCanBeMethodReference">
+        <properties>
+            <property name="ignoreIfMayNPE" value="false" />
+            <property name="ignoreIfReceiverIsMethod" value="true" />
+        </properties>
+    </rule>
     <rule ref="category/java/codestyle.xml/LinguisticNaming" />
     <rule ref="category/java/codestyle.xml/LocalHomeNamingConvention" />
     <rule ref="category/java/codestyle.xml/LocalInterfaceSessionNamingConvention" />
@@ -212,6 +224,7 @@
     <rule ref="category/java/errorprone.xml/CloseResource" />
     <rule ref="category/java/errorprone.xml/CompareObjectsWithEquals" />
     <rule ref="category/java/errorprone.xml/ComparisonWithNaN" />
+    <rule ref="category/java/errorprone.xml/ConfusingArgumentToVarargsMethod" />
     <rule ref="category/java/errorprone.xml/DetachedTestCase" />
     <rule ref="category/java/errorprone.xml/DoNotCallGarbageCollectionExplicitly" />
     <rule ref="category/java/errorprone.xml/DoNotExtendJavaLangThrowable" />

--- a/update_pmd.sh
+++ b/update_pmd.sh
@@ -18,7 +18,7 @@ today=$(date +"%Y%m%d")
 for tag in "$@"
 do
     git tag "${tag}_${today}"
-    git push origin "$tag_$today"
+    git push origin "${tag}_${today}"
 done
 
 # Print the number of tags created.

--- a/update_pmd.sh
+++ b/update_pmd.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+# Get the command line arguments.
+echo $@
+
+# Get the current date.
+today=$(date +"%Y%m%d")
+
+# Loop through all tags provided
+for tag in "$@"
+do
+    git tag "${tag}_${today}"
+    git push origin "$tag_$today"
+done
+
+# Print the number of tags created.
+echo "Created ${#@} tags."

--- a/update_pmd.sh
+++ b/update_pmd.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 set -e
 
+# Check if at least one tag has been provided
+if [ $# -eq 0 ]; then
+    echo "Error: At least one tag is required."
+    echo "Usage: update_pmd.sh <tag1> <tag2> ... <tagN>"
+    exit 1
+fi
+
 # Get the command line arguments.
 echo $@
 


### PR DESCRIPTION
This can't be merged to `master` without causing problems for any repositories using older versions of PMD.

When testing with `ConfusingArgumentToVarargsMethod` I found it generated a lot of false positives (e.g. `Set<String> MY_SET = Set.of(SOME_STRING);` triggered it to suggest casting to `String` or `String[]`). This seems likely to be the same as https://github.com/pmd/pmd/issues/5070